### PR TITLE
[CMP-2411] Fix Google Consent Mode developer ID format

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -168,7 +168,7 @@ if (queryPermission('get_cookies', COOKIE_NAME) && queryPermission('get_url', 'h
     log('No Cookie Permissions');
 }
 
-gtagSet('developerId.dMzRlOT', true);
+gtagSet('developer_id.dMzRlOT', true);
 const dataLayerPush = createQueue('dataLayer');
 
 const ccId = data.ccId || '';
@@ -703,7 +703,7 @@ ___WEB_PERMISSIONS___
             "listItem": [
               {
                 "type": 1,
-                "string": "developerId.dMzRlOT"
+                "string": "developer_id.dMzRlOT"
               }
             ]
           }


### PR DESCRIPTION
Updates the developer ID format in the GTM template **_developer_id_**.dMzRlOT

**Developer Checklist:**

- [x] JIRA IDs tagged in commits
- [x] all existing unit tests pass
- ~[ ] new unit tests written and pass~ n/a
- [x] linting passes
- [x] build completes without errors
- [x] overrides ran locally without errors
- [x] acceptance criteria tested locally
- ~[ ] README is up to date~
- ~[ ] .env.dev is up to date~
- ~[ ] public documentation is up to date~
- ~[ ] deployment requirements detailed in JIRA (if any)~
